### PR TITLE
Updates to ani_dataloader and MoleculeSet saving routine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# h5py files
+.h5

--- a/tensormol_jax/dataset/molecule.py
+++ b/tensormol_jax/dataset/molecule.py
@@ -6,7 +6,7 @@ and their properties (energy, atomic forces, dipole moments).
 
 import json
 import torch
-
+import numpy as np
 
 class MoleculeSet():
     def __init__(self):
@@ -14,7 +14,9 @@ class MoleculeSet():
         self.atomic_nums = ()
         self.geometries = []
         self.identifiers = {}
+        self.properties = {}
         self.min_geom = None
+        self.filename = None
 
     def __len__(self):
         return len(self.geometries)
@@ -26,12 +28,17 @@ class MoleculeSet():
         return self.geometries[idx]
 
     def save(self, filename=None):
-	# Will do some stuff to collect all necessary data into a format for JSON
-        if (filename == None):
-            filename = self.filename
+        if filename is None:
+            if self.filename is None:
+                # TODO This should be implemented as an error
+                print("No filename given for saving")
+                exit(0)
+            else:
+                filename = self.filename
+        print(type(self.atomic_nums))
         json_data = {
             "atomic_number": self.atomic_nums,
-            "coordinates": [geom.coords for geom in self.geometries],
+            "coordinates": [geom.coords.tolist() for geom in self.geometries],
             "properties": [geom.properties for geom in self.geometries],
             "identifiers": self.identifiers
         }
@@ -39,12 +46,16 @@ class MoleculeSet():
             json.dump(json_data, f)
 
     def load(self, filename=None):
-        self.filename = filename
+        if filename is None:
+            try:
+                filename = self.filename
+            except:
+                "No file specified for Molecule Set loading."
         with open(filename) as f:
             json_data = json.load(f)[0]
         self.atomic_nums = json_data['atomic_nums']
         self.geometries = [Geometry(geom) for geom in json_data['geometries']]
-        self.identifiers = {"identifiers": json_data['identifiers']}
+        # self.identifiers = {"identifiers": json_data['identifiers']}
 
 
 class Geometry:

--- a/tensormol_jax/util/ani_dataloader.py
+++ b/tensormol_jax/util/ani_dataloader.py
@@ -9,16 +9,10 @@ import numpy as np
 import json
 import sys
 
-# Path to the ANI-1x data set
-path_to_h5file = '/home/adriscoll/tensormol-jax/tensormol_jax/data/ani1x-release.h5'
+from ..dataset.molecule import MoleculeSet, Geometry
 
-argumentList = sys.argv
-argumentList.pop(0)
 
-# List of keys to point to requested data
-data_keys = np.array(argumentList)
-
-def iter_data_buckets(h5filename, keys=data_keys):
+def iter_data_buckets(h5filename, keys):
     """ Iterate over buckets of data in ANI HDF5 file.
     Yields dicts with atomic numbers (shape [Na,]) coordinated (shape [Nc, Na, 3])
     and other available properties specified by `keys` list, w/o NaN values.
@@ -42,55 +36,59 @@ def iter_data_buckets(h5filename, keys=data_keys):
             yield d
 
 
-json_data = []
-molecule_dict = {}
-
 name_dict = {
-    'coordinates':"geometries",
-    'atomic_numbers':"atomic_nums",
-    'wb97x_dz.energy':"total_dz_energy",
-    'wb97x_tz.energy':"total_tz_energy",
-    'ccsd(t)_cbs.energy':"total_cbs_energy",
-    'hf_dz.energy':"hf_dz_energy",
-    'hf_tz.energy':"hf_tz_energy",
-    'hf_qz.energy':"hf_qz_energy",
-    'npno_ccsd(t)_dz.corr_energy':"npno_dz_energy",
-    'npno_ccsd(t)_tz.corr_energy':"npno_tz_energy",
-    'npno_ccsd(t)_qz.corr_energy':"npno_qz_energy",
-    'mp2_dz.corr_energy':"mp2_dz_energy",
-    'mp2_tz.corr_energy':"mp2_tz_energy",
-    'mp2_qz.corr_energy':"mp2_qz_energy",
-    'wb97x_dz.forces':"atomic_dz_forces",
-    'wb97x_tz.forces':"atomic_tz_forces",
-    'wb97x_dz.dipole':"dipole_dz",
-    'wb97x_tz.dipole':"dipole_tz",
-    'wb97x_tz.quadrupole':"moments",
-    'wb97x_dz.cm5_charges':"cm5_charges",
-    'wb97x_dz.hirshfeld_charges':"hirshfeld_charges",
-    'wb97x_dz.mbis_charges':"mbis_charges",
-    'wb97x_dz.mbis_dipoles':"mbis_dipoles",
-    'wb97x_dz.mbis_quadrupoles':"mbis_electric",
-    'wb97x_dz.mbis_octupoles':"mbis_moments",
-    'wb97x_dz.mbis_volumes':"atomic_volumes"
+    'coordinates': "geometries",
+    'atomic_numbers': "atomic_nums",
+    'wb97x_dz.energy': "total_dz_energy",
+    'wb97x_tz.energy': "total_tz_energy",
+    'ccsd(t)_cbs.energy': "total_cbs_energy",
+    'hf_dz.energy': "hf_dz_energy",
+    'hf_tz.energy': "hf_tz_energy",
+    'hf_qz.energy': "hf_qz_energy",
+    'npno_ccsd(t)_dz.corr_energy': "npno_dz_energy",
+    'npno_ccsd(t)_tz.corr_energy': "npno_tz_energy",
+    'npno_ccsd(t)_qz.corr_energy': "npno_qz_energy",
+    'mp2_dz.corr_energy': "mp2_dz_energy",
+    'mp2_tz.corr_energy': "mp2_tz_energy",
+    'mp2_qz.corr_energy': "mp2_qz_energy",
+    'wb97x_dz.forces': "atomic_dz_forces",
+    'wb97x_tz.forces': "atomic_tz_forces",
+    'wb97x_dz.dipole': "dipole_dz",
+    'wb97x_tz.dipole': "dipole_tz",
+    'wb97x_tz.quadrupole': "moments",
+    'wb97x_dz.cm5_charges': "cm5_charges",
+    'wb97x_dz.hirshfeld_charges': "hirshfeld_charges",
+    'wb97x_dz.mbis_charges': "mbis_charges",
+    'wb97x_dz.mbis_dipoles': "mbis_dipoles",
+    'wb97x_dz.mbis_quadrupoles': "mbis_electric",
+    'wb97x_dz.mbis_octupoles': "mbis_moments",
+    'wb97x_dz.mbis_volumes': "atomic_volumes"
 }
-    
 
-# Example for extracting DFT/DZ energies and forces
-for data in iter_data_buckets(path_to_h5file, keys=data_keys):
-    X = data['coordinates']
-    Y = data['atomic_numbers']
-    molecule_dict.update({
-        "geometries":X.tolist(),
-        "atomic_nums":Y.tolist()
-    }) 
-    for key in data_keys:
-        if (key == 'coordinates') or (key == 'atomic_positions'):
-            continue
-        molecule_dict.update({
-            name_dict[key] : data[key].tolist()
-        }) 
-    json_data.append(molecule_dict)
 
-with open('../data/ani1x-release.json', 'w') as outfile:
-    json.dump(json_data, outfile, ensure_ascii=False)
+def load_ani1x(path_to_h5file, data_keys=[]):
+    # Example for extracting DFT/DZ energies and forces
+    msets = []
+    for data in iter_data_buckets(path_to_h5file, keys=data_keys):
+        mset = MoleculeSet()
+        prop_keys = []
+        for key in data.keys():
+            if key == 'atomic_numbers':
+                mset.atomic_nums = data['atomic_numbers'].tolist()
+            elif key == 'coordinates':
+                continue
+            else:
+                prop_keys.append(key)
+        for i, coords in enumerate(data['coordinates']):
+            g = Geometry(coords)
+            g.properties = {key: data[key][i].tolist() for key in prop_keys}
+            mset.geometries.append(g)
+        msets.append(mset)
+    # with open('../data/ani1x-release.json', 'w') as outfile:
+    #    json.dump(json_data, outfile, ensure_ascii=False)
 
+
+if __name__ == "__main__":
+    path_to_h5file = '/Users/johnherr/tensormol-jax/tensormol_jax/data/ani1x-release.h5'
+    data_keys = ['wb97x_tz.energy', 'wb97x_tz.forces']
+    json_data = load_ani1x(path_to_h5file, data_keys)


### PR DESCRIPTION
Updates the ani_dataloader script to accept input keys to load from the raw h5 file. Currently returns a list of MoleculeSet objects for each molecule in the dataset.

The MoleculeSet saving routine has also been updated to save the MoleculeSet data to a JSON file.